### PR TITLE
Fix getLogger function and refactor getFormatter

### DIFF
--- a/src/CLIFramework/Command.php
+++ b/src/CLIFramework/Command.php
@@ -91,7 +91,7 @@ abstract class Command extends CommandBase
      */
     public function getLogger()
     {
-        return $this->application->getLogger();
+        return $this->getApplication()->getLogger();
     }
 
 
@@ -103,10 +103,7 @@ abstract class Command extends CommandBase
      */
     public function getFormatter()
     {
-        if($this->application)
-            return $this->application->getFormatter();
-        else
-            return new Formatter;
+        return $this->getApplication()->getFormatter();
     }
 
     /**


### PR DESCRIPTION
Without that fix I get the following error if I run phpbrew:

```
PHP Fatal error:  Call to a member function getLogger() on a non-object in /var/www/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/Command.php on line 94
PHP Stack trace:
PHP   1. {main}() /var/www/phpbrew/bin/phpbrew:0
PHP   2. CLIFramework\Application->run() /var/www/phpbrew/bin/phpbrew:5
PHP   3. CLIFramework\CommandBase->executeWrapper() /var/www/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/Application.php:192
PHP   4. CLIFramework\Command->getLogger() /var/www/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/CommandBase.php:375

Fatal error: Call to a member function getLogger() on a non-object in /var/www/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/Command.php on line 94

Call Stack:
    0.0004     221184   1. {main}() /var/www/phpbrew/bin/phpbrew:0
    0.0772     700136   2. CLIFramework\Application->run() /var/www/phpbrew/bin/phpbrew:5
    0.1971    1443528   3. CLIFramework\CommandBase->executeWrapper() /var/www/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/Application.php:192
    0.1971    1444232   4. CLIFramework\Command->getLogger() /var/www/phpbrew/vendor/corneltek/cliframework/src/CLIFramework/CommandBase.php:375
```
