### PR TITLE
Bug fix in Application.php: incorrect guessCommand

### DIFF
--- a/src/CLIFramework/Application.php
+++ b/src/CLIFramework/Application.php
@@ -248,7 +248,7 @@ class Application extends CommandBase
                 $a = $getopt->getCurrentArgument();
 
                 if (!$currentCmd->hasCommand($a) ) {
-                    if (!$appOptions->noInteract && ($guess = $currentCmd->guessCommand($a) !== NULL)) {
+                    if (!$appOptions->noInteract && ($guess = $currentCmd->guessCommand($a)) !== NULL) {
                         $a = $guess;
                     } else {
                         throw new CommandNotFoundException($currentCmd, $a);


### PR DESCRIPTION
Incorrect parenthesis placement makes $guess would be only true or false since '!==' operator has higher precedence than '='
