### PR TITLE
New correct: use similar_text instead of levenshtein

### DIFF
--- a/src/CLIFramework/LevenshteinCorrector.php
+++ b/src/CLIFramework/LevenshteinCorrector.php
@@ -1,0 +1,41 @@
+<?php
+namespace CLIFramework;
+
+class LevenshteinCorrector extends Corrector
+{
+    public function match($input) {
+        // no shortest distance found, yet
+        $shortest = -1;
+
+        // loop through words to find the closest
+        foreach ($this->possibleTokens as $word) {
+
+            // calculate the distance between the input word,
+            // and the current word
+            $lev = levenshtein($input, $word);
+
+            // check for an exact match
+            if ($lev == 0) {
+
+                // closest word is this one (exact match)
+                $closest = $word;
+                $shortest = 0;
+
+                // break out of the loop; we've found an exact match
+                break;
+            }
+
+            // if this distance is less than the next found shortest
+            // distance, OR if a next shortest word has not yet been found
+            if ($lev <= $shortest || $shortest < 0) {
+                // set the closest match, and shortest distance
+                $closest  = $word;
+                $shortest = $lev;
+            }
+        }
+        return $closet;
+    }
+}
+
+
+


### PR DESCRIPTION
First draft of new Corrector.

Two complete separate Corrector class seems dumb. I do think once building an abstract Corrector class or a Corrector interface, however might not worth do it now until we can figure out how users would be interested in this part. So I currently still make base Corrector concrete instead of abstract or interface.
