### PR TITLE
Add a new feature of built-in daemon command.

### DIFF
--- a/cliframework.ini
+++ b/cliframework.ini
@@ -1,3 +1,4 @@
 [core]
 verbose = true
 debug = true
+pid_dir = /tmp

--- a/example/demo
+++ b/example/demo
@@ -28,6 +28,7 @@ require 'tests/DemoApp/Command/CommitCommand.php';
 require 'tests/DemoApp/Command/FooCommand.php';
 require 'tests/DemoApp/Command/AddCommand.php';
 require 'tests/DemoApp/Command/FooCommand/SubFooCommand.php';
+require 'tests/DemoApp/Command/ServerCommand.php';
 
 $app = new DemoApp\Application;
 $app->runWithTry($argv);

--- a/src/CLIFramework/Application.php
+++ b/src/CLIFramework/Application.php
@@ -164,6 +164,7 @@ class Application extends CommandBase
         $opts->add('version'  ,'Show version.');
 
         $opts->add('p|profile','Display timing and memory usage information.');
+        $opts->add('log-path?', 'The path of a log file.');
         // Un-implemented options
         $opts->add('no-interact','Do not ask any interactive question.');
         // $opts->add('no-ansi', 'Disable ANSI output.');
@@ -382,9 +383,10 @@ class Application extends CommandBase
     {
         $this->startedAt = microtime(true);
         $options = $this->getOptions();
-        if ($options->verbose) {
+        $config = $this->getGlobalConfig();
+        if ($options->verbose || $config->isVerbose()) {
             $this->getLogger()->setVerbose();
-        } elseif ($options->debug) {
+        } elseif ($options->debug || $config->isDebug()) {
             $this->getLogger()->setDebug();
         } elseif ($options->quiet) {
             $this->getLogger()->setLevel(2);
@@ -477,6 +479,11 @@ class Application extends CommandBase
     public function getLogger()
     {
         return $this->service['logger'];
+    }
+
+    private function getGlobalConfig()
+    {
+        return $this->service['config'];
     }
 
     public function __get($name) {

--- a/src/CLIFramework/Command.php
+++ b/src/CLIFramework/Command.php
@@ -63,6 +63,10 @@ abstract class Command extends CommandBase
         }
     }
 
+    public function hasApplication() {
+        return $this->getApplication() !== null;
+    }
+
     public function setName($name)
     {
         $this->name = $name;

--- a/src/CLIFramework/Config/GlobalConfig.php
+++ b/src/CLIFramework/Config/GlobalConfig.php
@@ -18,6 +18,11 @@ class GlobalConfig
      */
     private $isDebug = false;
 
+    /**
+     * @var string
+     */
+    private $pidDir;
+
     public function __construct($config)
     {
         $this->config = $config;
@@ -45,5 +50,16 @@ class GlobalConfig
             $this->isDebug = $this->config['core']['debug'] === '1';
         }
         return $this->isDebug;
+    }
+
+    /**
+     * Returns the directory of pid files.
+     */
+    public function getPidDirectory()
+    {
+        if (isset($this->config['core']['pid_dir'])) {
+            $this->pidDir = $this->config['core']['pid_dir'];
+        }
+        return $this->pidDir;
     }
 }

--- a/src/CLIFramework/Exception/ExtensionException.php
+++ b/src/CLIFramework/Exception/ExtensionException.php
@@ -1,0 +1,11 @@
+<?php
+namespace CLIFramework\Exception;
+use Exception;
+
+class ExtensionException extends \Exception
+{
+    public function __construct($message)
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/CLIFramework/Extension/DaemonExtension.php
+++ b/src/CLIFramework/Extension/DaemonExtension.php
@@ -90,9 +90,6 @@ class DaemonExtension extends ExtensionBase
     private function bindOptions($command)
     {
         $options = $command->getOptionCollection();
-        if (!$options) {
-            return;
-        }
         $options->add('pid-file?', 'The path of pid file.');
     }
 

--- a/src/CLIFramework/Extension/DaemonExtension.php
+++ b/src/CLIFramework/Extension/DaemonExtension.php
@@ -1,0 +1,189 @@
+<?php
+namespace CLIFramework\Extension;
+
+use CLIFramework\ServiceContainer;
+use CLIFramework\Command;
+use CLIFramework\Logger;
+use CLIFramework\Exception\ExtensionException;
+use CLIFramework\IO\StreamWriter;
+
+class DaemonExtension extends ExtensionBase
+{
+    private $config;
+    private $logger;
+    private $isNoClose = false;
+    private $isNoChangeDirectory = false;
+    private $command;
+
+    public function __construct()
+    {
+        $container = ServiceContainer::getInstance();
+        $this->config = $container['config'];
+    }
+
+    public static function isAvailable()
+    {
+        return function_exists('pcntl_fork');
+    }
+
+    public function bind(Command $command)
+    {
+        $this->command = $command;
+        $this->bindOptions($command);
+        $this->bindHooks($command);
+    }
+
+    public function run()
+    {
+        if (!$this->isAvailable()) {
+            throw new ExtensionException("pcntl_fork() is not supported.");
+        }
+
+        $this->prepareLogger();
+        $logger = $this->getLogger();
+        $logger->debug('call hook: run.before');
+        $this->callHook('run.before');
+        $logger->debug('call daemonize()');
+        $this->daemonize();
+        $logger->debug('call hook: run.after');
+        $this->callHook('run.after');
+        $logger->debug('isNoClose = ' . var_export($this->isNoClose, true));
+        $logger->debug('isNoChangeDirectory = ' . var_export($this->isNoChangeDirectory, true));
+        $logger->debug('PidFilePath = ' . $this->getPidFilePath());
+    }
+
+    public function noClose()
+    {
+        $this->isNoClose = true;
+    }
+
+    public function noChangeDirectory()
+    {
+        $this->isNoChangeDirectory = true;
+    }
+
+    public function getPidFilePath()
+    {
+        $pid = getmypid();
+        $pidFileName = $this->command ? $this->command->getName() : $pid;
+        return $this->config->getPidDirectory() . "/$pidFileName.pid";
+    }
+
+    private function bindHooks($command)
+    {
+        $extension = $this;
+        $command->addHook('execute.before', function() use ($extension) {
+            $extension->run();
+        });
+        $command->addHook('execute.after', function() use ($extension) {
+            @unlink($extension->getPidFilePath());
+        });
+    }
+
+    private function bindOptions($command)
+    {
+        $options = $command->getOptionCollection();
+        if (!$options) {
+            return;
+        }
+        $options->add('pid-file', 'The path of pid file.');
+    }
+
+    private function prepareLogger()
+    {
+        $logPath = $this->getLogPath();
+        $logger = $this->getLogger();
+
+        if (!$logPath || !$logger) {
+            return;
+        }
+
+        $resource = fopen($logPath, "a+");
+
+        if ($resource === false) {
+            throw new ExtensionException("Can't open file: $logPath");
+        }
+
+        // TODO change logging style
+        $logger->setWriter(new StreamWriter($resource));
+    }
+
+    private function daemonize()
+    {
+        switch (pcntl_fork()) {
+        case -1:
+            throw new ExtensionException("pcntl_fork() failed");
+        case 0:
+            break;
+        default:
+            exit(0);
+        }
+
+        if (!$this->createPidFile()) {
+            throw new ExtensionException("creating a pid file failed");
+        }
+
+        if (!$this->isNoChangeDirectory) {
+            $this->changeDirectory();
+        }
+
+        if (!$this->isNoClose) {
+            $this->closeFileDescriptors();
+        }
+
+    }
+
+    private function changeDirectory()
+    {
+        if (!$this->isNoChangeDirectory && !chdir("/")) {
+            throw new ExtensionException("chdir failed");
+        }
+    }
+
+    private function closeFileDescriptors()
+    {
+        if (!fclose(STDIN)) {
+            throw new ExtensionException("fclose(STDIN) failed");
+        }
+
+        if (!fclose(STDOUT)) {
+            throw new ExtensionException("fclose(STDOUT) failed");
+        }
+
+        if (!fclose(STDERR)) {
+            throw new ExtensionException("fclose(STDERR) failed");
+        }
+    }
+
+    private function createPidFile()
+    {
+        return file_put_contents($this->getPidFilePath(), getmypid());
+    }
+
+    private function getLogPath()
+    {
+        if (!$this->hasApplication()) {
+            return null;
+        }
+        $options = $this->command->getApplication()->getOptions();
+        return $options && $options->{'log-path'} ? $options->{'log-path'} : null;
+    }
+
+    private function getLogger()
+    {
+        if ($this->hasApplication()) {
+            $this->logger = $this->command->getLogger();
+        }
+
+        if (!$this->logger) {
+            $this->logger = new Logger();
+        }
+
+        return $this->logger;
+    }
+
+    private function hasApplication()
+    {
+        return $this->command && $this->command->hasApplication();
+    }
+}

--- a/src/CLIFramework/Extension/DaemonExtension.php
+++ b/src/CLIFramework/Extension/DaemonExtension.php
@@ -128,23 +128,23 @@ class DaemonExtension extends ExtensionBase
         }
 
         if ($this->chdir) {
-            $this->changeDirectoryToRoot();
+            $this->chdir();
         }
 
         if ($this->detach) {
-            $this->closeFileDescriptors();
+            $this->detach();
         }
 
     }
 
-    private function changeDirectoryToRoot()
+    private function chdir()
     {
         if ($this->chdir && !chdir("/")) {
             throw new ExtensionException("chdir failed");
         }
     }
 
-    private function closeFileDescriptors()
+    private function detach()
     {
         if (!fclose(STDIN)) {
             throw new ExtensionException("fclose(STDIN) failed");

--- a/src/CLIFramework/Extension/DaemonExtension.php
+++ b/src/CLIFramework/Extension/DaemonExtension.php
@@ -64,9 +64,12 @@ class DaemonExtension extends ExtensionBase
 
     public function getPidFilePath()
     {
+        if ($this->getCommandOptions() && $this->getCommandOptions()->{'pid-file'}) {
+            return $this->getCommandOptions()->{'pid-file'};
+        }
         $pid = getmypid();
-        $pidFileName = $this->command ? $this->command->getName() : $pid;
-        return $this->config->getPidDirectory() . "/$pidFileName.pid";
+        $pidFile = $this->command ? $this->command->getName() : $pid;
+        return $this->config->getPidDirectory() . "/$pidFile.pid";
     }
 
     private function bindHooks($command)
@@ -86,7 +89,7 @@ class DaemonExtension extends ExtensionBase
         if (!$options) {
             return;
         }
-        $options->add('pid-file', 'The path of pid file.');
+        $options->add('pid-file?', 'The path of pid file.');
     }
 
     private function prepareLogger()
@@ -162,10 +165,7 @@ class DaemonExtension extends ExtensionBase
 
     private function getLogPath()
     {
-        if (!$this->hasApplication()) {
-            return null;
-        }
-        $options = $this->command->getApplication()->getOptions();
+        $options = $this->getApplicationOptions();
         return $options && $options->{'log-path'} ? $options->{'log-path'} : null;
     }
 
@@ -180,6 +180,19 @@ class DaemonExtension extends ExtensionBase
         }
 
         return $this->logger;
+    }
+
+    private function getApplicationOptions()
+    {
+        if (!$this->hasApplication()) {
+            return null;
+        }
+        return $this->command->getApplication()->getOptions();
+    }
+
+    private function getCommandOptions()
+    {
+        return $this->command ? $this->command->getOptions() : null;
     }
 
     private function hasApplication()

--- a/src/CLIFramework/Extension/Extension.php
+++ b/src/CLIFramework/Extension/Extension.php
@@ -1,0 +1,9 @@
+<?php
+namespace CLIFramework\Extension;
+
+use CLIFramework\Command;
+
+interface Extension
+{
+    public function bind(Command $command);
+}

--- a/src/CLIFramework/Extension/ExtensionBase.php
+++ b/src/CLIFramework/Extension/ExtensionBase.php
@@ -1,0 +1,42 @@
+<?php
+namespace CLIFramework\Extension;
+
+use CLIFramework\ServiceContainer;
+use CLIFramework\Command;
+use CLIFramework\Hook\Hookable;
+use CLIFramework\Hook\HookHolder;
+use CLIFramework\Exception\ExtensionException;
+
+abstract class ExtensionBase
+    implements Extension, Hookable
+{
+    private $hooks;
+
+    private function getHooks()
+    {
+        if (!$this->hooks) {
+            $this->hooks = new HookHolder();
+        }
+        return $this->hooks;
+    }
+
+    public function getHookPoints()
+    {
+        return $this->getHooks()->getHookPoints();
+    }
+
+    public function addHook($name, \Closure $callback)
+    {
+        $this->getHooks()->addHook($name, $callback);
+    }
+
+    public function addHookByArray(array $options)
+    {
+        $this->getHooks()->addHookByArray($options);
+    }
+
+    public function callHook($name)
+    {
+        call_user_func_array(array($this->getHooks(), 'callHook'), func_get_args());
+    }
+}

--- a/src/CLIFramework/Hook/HookHolder.php
+++ b/src/CLIFramework/Hook/HookHolder.php
@@ -1,0 +1,45 @@
+<?php
+namespace CLIFramework\Hook;
+
+class HookHolder implements Hookable
+{
+    private $hooks = array();
+
+    public function addHook($name, \Closure $callback)
+    {
+        $this->addHookByArray(array('name' => $name, 'callback' => $callback));
+    }
+
+    public function addHookByArray(array $options)
+    {
+        $name = $options['name'];
+
+        if (!$this->hasHook($name)) {
+            $this->hooks[$name] = array();
+        }
+
+        $this->hooks[$name][] = $options['callback'];
+    }
+
+    public function callHook($name)
+    {
+        if (!$this->hasHook($name)) {
+            return;
+        }
+
+        $callbackArgs = array_slice(func_get_args(), 1);
+        foreach ($this->hooks[$name] as $callback) {
+            call_user_func_array($callback ,$callbackArgs);
+        }
+    }
+
+    public function getHookPoints()
+    {
+        return array_keys($this->hooks);
+    }
+
+    private function hasHook($name)
+    {
+        return isset($this->hooks[$name]);
+    }
+}

--- a/src/CLIFramework/Hook/Hookable.php
+++ b/src/CLIFramework/Hook/Hookable.php
@@ -1,0 +1,13 @@
+<?php
+namespace CLIFramework\Hook;
+
+interface Hookable
+{
+    public function addHook($name, \Closure $callback);
+    public function callHook($name /** , $args...*/);
+
+    /**
+     * @return array
+     */
+    public function getHookPoints();
+}

--- a/src/CLIFramework/IO/StreamWriter.php
+++ b/src/CLIFramework/IO/StreamWriter.php
@@ -11,6 +11,10 @@ class StreamWriter implements Writer
 
     public function __construct($stream)
     {
+        if (!is_resource($stream)) {
+            throw new \RuntimeException("invalid stream");
+        }
+
         $this->stream = $stream;
     }
 

--- a/tests/CLIFramework/CommandTest.php
+++ b/tests/CLIFramework/CommandTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace tests\CLIFramework;
+
+use CLIFramework\Command;
+use CLIFramework\Application;
+
+class CommandTest extends \PHPUnit_Framework_TestCase
+{
+    private $command;
+
+    public function setUp()
+    {
+        $this->command = new CommandTestCommand();
+    }
+
+    public function testHasApplicationWhenApplicationIsNotSet()
+    {
+        $this->assertFalse($this->command->hasApplication());
+    }
+
+    public function testHasApplicationWhenApplicationIsSet()
+    {
+        $this->command->setApplication(new Application);
+        $this->assertTrue($this->command->hasApplication());
+    }
+}
+
+class CommandTestCommand extends Command
+{
+    public function execute()
+    {
+    }
+}

--- a/tests/CLIFramework/Config/GlobalConfigTest.php
+++ b/tests/CLIFramework/Config/GlobalConfigTest.php
@@ -44,6 +44,16 @@ class GlobalConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($config->isDebug());
     }
 
+    /**
+     * @test
+     * @dataProvider provideSampleConfig
+     */
+    public function testGetPidDirectory($sampleConfig)
+    {
+        $config = new GlobalConfig($sampleConfig);
+        $this->assertSame('/var/run', $config->getPidDirectory());
+    }
+
     public function provideSampleConfig()
     {
         return array(

--- a/tests/CLIFramework/Extension/DaemonExtensionTest.php
+++ b/tests/CLIFramework/Extension/DaemonExtensionTest.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * This file is part of the CLIFramework package.
+ *
+ * (c) Yo-An Lin <cornelius.howl@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+namespace tests\CLIFramework\Extension;
+
+use CLIFramework\Extension\DaemonExtension;
+use CLIFramework\Command;
+
+class DaemonExtensionTest extends \PHPUnit_Framework_TestCase 
+{
+    private $extension;
+    private $command;
+
+    function setUp()
+    {
+        if (!DaemonExtension::isAvailable()) {
+            $this->markTestSkipped('DaemonExtension is not available.');
+        }
+        $this->extension = new DaemonExtension();
+        $this->extension->noClose();
+        $this->command = new DaemonExtensionTestCommand();
+        $this->extension->bind($this->command);
+    }
+
+    function tearDown()
+    {
+        $this->command->callHook('execute.after');
+        $this->assertFalse(file_exists($this->extension->getPidFilePath()));
+    }
+
+    function testCallHookBeforeRun()
+    {
+        $isSuccess = false;
+
+        $this->extension->addHook('run.before', function() use (&$isSuccess) {
+            $isSuccess = true;
+        });
+
+        $this->extension->run();
+
+        $this->assertTrue($isSuccess);
+    }
+
+    function testCallHookAfterRun()
+    {
+        $isSuccess = false;
+
+        $this->extension->addHook('run.after', function() use (&$isSuccess) {
+            $isSuccess = true;
+        });
+
+        $this->extension->run();
+
+        $this->assertTrue($isSuccess);
+    }
+
+    function testBind()
+    {
+        $this->assertFalse(file_exists($this->extension->getPidFilePath()));
+        $this->command->callHook('execute.before');
+        $this->assertTrue(file_exists($this->extension->getPidFilePath()));
+    }
+
+    function testRun()
+    {
+        $pid = getmypid();
+        $this->extension->run();
+        $this->assertTrue($pid !== getmypid());
+    }
+}
+
+class DaemonExtensionTestCommand extends Command
+{
+    public function execute()
+    {
+    }
+}

--- a/tests/CLIFramework/Extension/DaemonExtensionTest.php
+++ b/tests/CLIFramework/Extension/DaemonExtensionTest.php
@@ -23,8 +23,8 @@ class DaemonExtensionTest extends \PHPUnit_Framework_TestCase
         if (!DaemonExtension::isAvailable()) {
             $this->markTestSkipped('DaemonExtension is not available.');
         }
-        $this->extension = new DaemonExtension();
-        $this->extension->noClose();
+        $this->extension = new DaemonExtensionForTest();
+        $this->extension->noDetach();
         $this->command = new DaemonExtensionTestCommand();
         $this->extension->bind($this->command);
     }
@@ -73,6 +73,14 @@ class DaemonExtensionTest extends \PHPUnit_Framework_TestCase
         $pid = getmypid();
         $this->extension->run();
         $this->assertTrue($pid !== getmypid());
+    }
+}
+
+class DaemonExtensionForTest extends DaemonExtension
+{
+    public function noDetach()
+    {
+        parent::noDetach();
     }
 }
 

--- a/tests/CLIFramework/Extension/DaemonExtensionTest.php
+++ b/tests/CLIFramework/Extension/DaemonExtensionTest.php
@@ -12,6 +12,7 @@ namespace tests\CLIFramework\Extension;
 
 use CLIFramework\Extension\DaemonExtension;
 use CLIFramework\Command;
+use CLIFramework\Application;
 
 class DaemonExtensionTest extends \PHPUnit_Framework_TestCase 
 {
@@ -26,6 +27,8 @@ class DaemonExtensionTest extends \PHPUnit_Framework_TestCase
         $this->extension = new DaemonExtensionForTest();
         $this->extension->noDetach();
         $this->command = new DaemonExtensionTestCommand();
+        $this->command->setApplication(new Application());
+        $this->command->_init();
         $this->extension->bind($this->command);
     }
 

--- a/tests/CLIFramework/Hook/HookHolderTest.php
+++ b/tests/CLIFramework/Hook/HookHolderTest.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * This file is part of the CLIFramework package.
+ *
+ * (c) Yo-An Lin <cornelius.howl@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+namespace tests\CLIFramework\Hook;
+
+use CLIFramework\Hook\HookHolder;
+
+class HookHolderTest extends \PHPUnit_Framework_TestCase 
+{
+    private $holder;
+
+    function setUp()
+    {
+        $this->holder = new HookHolder();
+    }
+
+    function testAddHook()
+    {
+        $this->assertCount(0, $this->holder->getHookPoints());
+
+        $this->holder->addHook('test.before', function() {});
+        $points = $this->holder->getHookPoints();
+
+        $this->assertCount(1, $points);
+        $this->assertSame('test.before', $points[0]);
+    }
+
+    function testAddHookByArray()
+    {
+        $this->assertCount(0, $this->holder->getHookPoints());
+
+        $this->holder->addHookByArray(array(
+            'name' => 'test.after',
+            'callback' => function() {}
+        ));
+        $points = $this->holder->getHookPoints();
+
+        $this->assertCount(1, $points);
+        $this->assertSame('test.after', $points[0]);
+    }
+
+    function testCallHook()
+    {
+        $tester = $this;
+        $isSuccess = false;
+
+        $this->holder->addHook('test.success', function() use (&$isSuccess) {
+            $isSuccess = true;
+        });
+        $this->holder->addHook('test.fail', function() use ($tester) {
+            $tester->fail();
+        });
+        $this->holder->callHook('test.success');
+
+        $this->assertTrue($isSuccess);
+    }
+}

--- a/tests/DemoApp/Application.php
+++ b/tests/DemoApp/Application.php
@@ -12,6 +12,7 @@ class Application extends \CLIFramework\Application {
         $this->command('foo');
         $this->command('add');
         $this->command('commit');
+        $this->command('server');
         $this->topic('basic');
     }
 }

--- a/tests/DemoApp/Command/ServerCommand.php
+++ b/tests/DemoApp/Command/ServerCommand.php
@@ -1,0 +1,37 @@
+<?php
+namespace DemoApp\Command;
+
+use CLIFramework\Command;
+use CLIFramework\Extension\DaemonExtension;
+
+class ServerCommand extends Command {
+    public function brief()
+    {
+        return 'An example of using DaemonExtension';
+    }
+
+    public function init()
+    {
+        $this->enableExtension(new DaemonExtension());
+    }
+
+    public function execute($host, $port)
+    {
+
+        $server = stream_socket_server("tcp://$host:$port", $errno, $errorMessage);
+
+        if ($server === false) {
+            throw new \RuntimeException("Could not bind to socket: $errorMessage");
+        }
+
+        for (;;) {
+            $socket = @stream_socket_accept($server);
+
+            if ($socket) {
+                $text = fread($socket, 1024);
+                $this->getLogger()->writeln($text);
+                fclose($socket);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ref: https://github.com/c9s/CLIFramework/issues/33

I've implemented a built-in daemon command. The new `Extension` and hook system are described at the above issue.

## How to try
Check my branch out and execute the following shell commands:

```bash
$ php example/demo --log-path=/tmp/server.log server --pid-file=/tmp/sample.pid 127.0.0.1 12345
$ echo 'Hello, world!' | netcat 127.0.0.1 12345
$ tail /tmp/server.log
```
`php example/demo server` launches an echo server, so that's ok if you can see 'Hello, world!' in the log file.

## execution steps for ServerCommand and DaemonExtension
1. ServerCommand::init()
2. ServerCommand::enableExtension(new DaemonExtension())
3. ServerCommand::_init()
4. ServerCommand::initExtensions()
5. DaemonExtension::bind($command)
6. ServerCommand::executeWrappers()
7. ServerCommand::callHook('execute.before')
8. DaemonExtension::callHook('run.before')
9. DaemonExtension::run()
10. DaemonExtension::daemonize()
11. DaemonExtension::callHook('run.after')
12. ServerCommand::execute()
13. ServerCommand::callHook('execute.after')

## ChangeLogs
* add `CLIFramework\Hook` namespace and support hook system.
* `CommandBase` and `ExtensionBase` implement `Hookable` interface.
* support global `--log-path` option and daemon command outputs logs to the path if `--log-path` is given.
* call `Logger::setVerbose` and `Logger::setDebug` on preparing `Application` if verbose and debug are set in cliframework.ini
* add `Command::hasApplication` in order to confirm whether we can get application or not.