### PR TITLE
Avoiding double newline after synopsis

### DIFF
--- a/src/CLIFramework/Command/HelpCommand.php
+++ b/src/CLIFramework/Command/HelpCommand.php
@@ -133,7 +133,7 @@ class HelpCommand extends Command implements CommandInterface {
             foreach($prototypes as $prototype) {
                 $logger->writeln("\t" . ' ' . $prototype);
             }
-            $logger->write("\n\n");
+            $logger->write("\n");
 
 
             if ($optionLines = $printer->render($cmd->optionSpecs)) {


### PR DESCRIPTION
There's always a newline char after the synopsis line. So we need only one more to separate from the next section.