### PR TITLE
Fix Compile Command

### DIFF
--- a/src/CLIFramework/Command/CompileCommand.php
+++ b/src/CLIFramework/Command/CompileCommand.php
@@ -170,8 +170,10 @@ require 'phar://$pharFile/$classloader_file';
 EOT;
             }
             else {
+                $classloader_interface = 'Universal/ClassLoader/ClassLoader.php';
                 $classloader_file = 'Universal/ClassLoader/SplClassLoader.php';
                 $stub .=<<<"EOT"
+require 'phar://$pharFile/$classloader_interface';
 require 'phar://$pharFile/$classloader_file';
 \$classLoader = new \\Universal\\ClassLoader\\SplClassLoader;
 \$classLoader->addFallback( 'phar://$pharFile' );


### PR DESCRIPTION
Relates to https://github.com/phpbrew/phpbrew/issues/561
There seems to be a subtle bc break on Universal\*, requiring an interface to be loaded from now on.