### PR TITLE
New command parser

### DIFF
--- a/src/Testing/CommandTestCase.php
+++ b/src/Testing/CommandTestCase.php
@@ -33,7 +33,7 @@ abstract class CommandTestCase extends PHPUnit_Framework_TestCase
 
     public function runCommand($args) {
         if (is_string($args)) {
-            $args = preg_split('/\s+/',$args);
+            $args = Parser::getArguments($args);
         }
         return $this->app->run($args);
     }

--- a/src/Testing/Parser.php
+++ b/src/Testing/Parser.php
@@ -1,0 +1,35 @@
+<?php
+namespace CLIFramework\Testing;
+
+class Parser
+{
+    public static function getArguments($command)
+    {
+        $command = self::normalizeCommand($command);
+        $result = array();
+        $i = 0;
+        $next = strpos($command, " ");
+        while ($next)
+        {
+            if ($command[$i] == "\"")
+            {
+                $i = $i + 1;
+                $next = strpos($command, "\"", $i);
+            }
+
+            $result[] = substr($command, $i, $next - $i);
+            $i = $next + 1;
+            $next = strpos($command, " ", $i);
+        }
+
+        $result[] = substr($command, $i, strlen($command) - $i);
+        return $result;
+    }
+
+    public static function normalizeCommand($command)
+    {
+        $command = preg_replace('/\s+/', ' ', $command);
+        return preg_replace('/"\s+/', '"', $command);
+    }
+}
+?>

--- a/tests/CLIFramework/Testing/ParserTest.php
+++ b/tests/CLIFramework/Testing/ParserTest.php
@@ -1,0 +1,35 @@
+<?php
+namespace tests\CLIFramework\Testing;
+
+use CLIFramework\Testing\Parser;
+
+class ParserTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetArguments_OneArgument()
+    {
+        $command = "program arg1";
+        $expect = array("program", "arg1");
+
+        $result = Parser::getArguments($command);
+        $this->assertEquals($expect, $result);
+    }
+
+    public function testGetArguments_TwoArguments()
+    {
+        $command = "program arg1    arg2";
+        $expect = array("program", "arg1", "arg2");
+
+        $result = Parser::getArguments($command);
+        $this->assertEquals($expect, $result);
+    }
+
+    public function testGetArguments_ArgumentWithSpaces()
+    {
+        $command = "program arg1 \"arg2.1 arg2.2\" arg3";
+        $expect = array("program", "arg1", "arg2.1 arg2.2", "arg3");
+
+        $result = Parser::getArguments($command);
+        $this->assertEquals($expect, $result);
+    }
+}
+?>


### PR DESCRIPTION
Relates to #92 

These changes permits to run commands in tests like we do in the command line. For example we can execute:
```
public function test()
{
    // ...
    $this->runCommand("program arg1 \"arg2.1 arg2.2\" arg3");
    // ...
}
```