### PR TITLE
Fixed problem with invalid implementation of OnionPrinterInterface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ matrix:
   - php: 5.5
   - php: 5.6
 
+git:
+  depth: 1
+
 install:
   - phpenv rehash
   - travis_retry composer self-update

--- a/src/OptionPrinter.php
+++ b/src/OptionPrinter.php
@@ -11,7 +11,7 @@
 namespace CLIFramework;
 use GetOptionKit\OptionCollection;
 use GetOptionKit\Option;
-use GetOptionKit\OptionPrinter\OptionPrinterInterface;
+use GetOptionKit\OptionPrinter\OptionPrinter as OptionPrinterInterface;
 use CLIFramework\Formatter;
 
 class OptionPrinter implements OptionPrinterInterface


### PR DESCRIPTION
I don't know, maybe after upgrade [GetOptionKit](https://github.com/c9s/GetOptionKit) package, `implements` value in `OptionPrinter.php` was invalid. It should refer to `OptionPrinter`, instead of `OptionPrinterInterface`. I fixed it and now CLIFramework works fine.