### PR TITLE
`Chooser`: Detection of associative arrays update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+# dev-master
+
+- Chooser component update to support associative arrays properly.
+
 Version 3.0.0
 
 - Added Progress Component.
-
 
 Version 2.8.1
 

--- a/src/Chooser.php
+++ b/src/Chooser.php
@@ -36,19 +36,21 @@ class Chooser
         echo $prompt . ": \n";
 
         $choicesMap = array();
+        $isAssoc = (array_keys($choices) !== range(0, count($choices) - 1));
 
-        // Not an indexed array
-        if (! isset($choices[0])) {
-            $i = 0;
+        $i = 0;
+        if($isAssoc) {
             foreach ($choices as $choice => $value) {
                 $i++;
                 $choicesMap[ $i ] = $value;
-                echo "\t" . ($i) . "  $choice\n";
+                echo "\t$i: " . $choice . " => " . $value . "\n";
             }
         } else {
-            foreach ($choices as $choice => $desc) {
-                $choicesMap[$choice] = $choice;
-                echo "\t$choice: $desc\n";
+            //is sequential
+            foreach ($choices as $choice) {
+                $i++;
+                $choicesMap[ $i ] = $choice;
+                echo "\t$i: $choice\n";
             }
         }
 
@@ -60,7 +62,7 @@ class Chooser
         $choosePrompt = "Please Choose 1-$i > ";
         while (1) {
             if (extension_loaded('readline')) {
-                $success = readline_completion_function(function($string, $index) use ($completionItems) { 
+                $success = readline_completion_function(function($string, $index) use ($completionItems) {
                     return $completionItems;
                 });
                 $answer = readline($choosePrompt);


### PR DESCRIPTION
There seems to be a bug triggered on simple arrays:
```php
$options = arrray('foo', 'bar', 'ccc');
```
Error:
```bash
Notice: Undefined variable: i in <...some path...>/vendor/corneltek/cliframework/src/Chooser.php on line 60
```

Applied a fix in detection of associative arrays, merging into `master` as not sure if your `develop` is actively maintained.

For:
```php
$options = array('foo','bar','foobar','barfoo');
$chooser = new \CLIFramework\Chooser;
$value = $chooser->choose( "Options" , $options);
```

Will show:
```bash
        1: foo
        2: bar
        3: foobar
        4: barfoo
```

For:
```php
$options = array(0=>'foo',2=>'bar',3=>'foobar',6=>'barfoo');
```

Will show:
```bash
        1: 0 => foo
        2: 2 => bar
        3: 3 => foobar
        4: 6 => barfoo
Please Choose 1-4 > 3
string(12) "Used: foobar"
```

For:
```php
$options = array(0=>'foo',1=>'bar',2=>'foobar',3=>'barfoo');
```

Will show:
```bash
        1: foo
        2: bar
        3: foobar
        4: barfoo
```

For:
```php
$options = array("a"=>'foo',"b"=>'bar',"c"=>'foobar',"d"=>'barfoo');
```

Will show:
```bash
        1: a => foo
        2: b => bar
        3: c => foobar
        4: d => barfoo
```
	
	