### PR TITLE
Fixed bug where psr4 autoload generator wasn't putting paths inside array

### DIFF
--- a/src/Autoload/ComposerAutoloadGenerator.php
+++ b/src/Autoload/ComposerAutoloadGenerator.php
@@ -250,7 +250,7 @@ class ComposerAutoloadGenerator
             // translate psr-4 mapping for Psr4ClassLoader
             $arg = array();
             foreach ($psr4 as $prefix => $paths) {
-                $arg[] = array($prefix, $paths);
+                $arg[] = array($prefix, [$paths]);
             }
             $block[] = new AssignStatement('$psr4', new NewObjectExpr('Psr4ClassLoader', array($arg)));
             $block[] = new MethodCallStatement('$psr4', 'register', array(false));


### PR DESCRIPTION
Corneltek's Universal library expects psr4 mappings to have paths inside an array.
Currently, the path is passed as a string.