### PR TITLE
Return FALSE in case of invalid arguments passed to a command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-composer.lock
-vendor/
-src/PHPBrew/
-build/
-.onion
 .hhconfig
+.onion
+build/
+composer.lock
+src/PHPBrew/
+vendor/
+tmp/

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     },
     "require-dev": {
         "corneltek/phpunit-testmore": "dev-master",
-        "satooshi/php-coveralls": "^1"
+        "satooshi/php-coveralls": "^1",
+        "phpunit/phpunit": "^5.7"
     },
     "license": "MIT",
     "authors": [

--- a/src/Application.php
+++ b/src/Application.php
@@ -407,7 +407,8 @@ class Application extends CommandBase
         }
         $currentCmd->finish();
         $this->finish();
-        return true;
+
+        return $return !== false;
     }
 
     /**

--- a/src/CommandBase.php
+++ b/src/CommandBase.php
@@ -814,7 +814,8 @@ abstract class CommandBase
 
                 if ($valid === FALSE) {
                     $this->logger->error($message ?: "Invalid argument $arg");
-                    return;
+
+                    return false;
                 }
             }
         }


### PR DESCRIPTION
Commands still can return any values or not return anything. Only explicitly returned `FALSE` will be interpreted as an error.

Fixes #106.