### PR TITLE
Do not display the "from" section for the first exception trace entry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: precise
 matrix:
   include:
   - php: 5.3

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "corneltek/phpunit-testmore": "dev-master",
         "satooshi/php-coveralls": "^1",
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^4.8 || ^5.7"
     },
     "license": "MIT",
     "authors": [

--- a/src/ExceptionPrinter/DevelopmentExceptionPrinter.php
+++ b/src/ExceptionPrinter/DevelopmentExceptionPrinter.php
@@ -97,8 +97,23 @@ class DevelopmentExceptionPrinter
 
             $argDesc = $this->dumpArgs($entry['args']);
 
-            $this->logger->info(sprintf("    %d) %s%s%s(%s)", $idx, @$entry['class'], @$entry['type'], $entry['function'], $argDesc));
-            $this->logger->info(sprintf("        from %s: %d", $entry['file'], $entry['line']));
+            $this->logger->info(sprintf(
+                "    %d) %s%s%s(%s)",
+                $idx + 1,
+                @$entry['class'],
+                @$entry['type'],
+                $entry['function'],
+                $argDesc
+            ));
+
+            if (isset($entry['file'], $entry['line'])) {
+                $this->logger->info(sprintf(
+                    "        from %s: %d",
+                    $entry['file'],
+                    $entry['line']
+                ));
+            }
+
             $this->logger->newline();
         }
         $this->logger->newline();
@@ -141,7 +156,7 @@ class DevelopmentExceptionPrinter
         }
     }
 
-    public function dump(Exception $e) 
+    public function dump(Exception $e)
     {
         $this->dumpBrief($e);
         $this->dumpCodeBlock($e);


### PR DESCRIPTION
According to http://php.net/manual/en/exception.gettrace.php#107563, the first entry doesn't contain the file/line keys since they are recorded in the exception object itself.

Additionally, some changes to the output formatting have been made:

1. The trace entries are counted in a human-friendly way starting with "1" (like Xdebug does for example).
2. The file name and line number in the "from" section are delimited by a colon without the space. This format is better IDE/editor friendly and helps easier navigation (e.g. Ctrl+N in PhpStorm, copy-paste the file:line combination).

With this patch applied, the output looks like the following:
```
↪ phpbrew --debug install 7.1.99
Exception: Version 7.1.99 not found.
Thrown from /home/morozov/Projects/phpbrew/src/PhpBrew/Command/InstallCommand.php at line 217:

  214            $version = preg_replace('/^php-/', '', $version);
  215            $versionInfo = $releaseList->getVersion($version);
  216            if (!$versionInfo) {
> 217                throw new \Exception("Version $version not found.");
  218            }
  219            $version = $versionInfo['version'];
  220
  221            $distUrlPolicy = new DistributionUrlPolicy();

Trace:

    1) PhpBrew\Command\InstallCommand->execute('7.1.99')

    2) call_user_func_array([PhpBrew\Command\InstallCommand, 'execute'], ['7.1.99'])
        from /home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/CommandBase.php:846

    3) CLIFramework\CommandBase->executeWrapper(['7.1.99'])
        from /home/morozov/Projects/phpbrew/vendor/corneltek/cliframework/src/Application.php:398

    4) CLIFramework\Application->run(['bin/phpbrew', '--debug', 'install', '7.1.99'])
        from /home/morozov/Projects/phpbrew/src/PhpBrew/Console.php:114

    5) PhpBrew\Console->runWithTry(['bin/phpbrew', '--debug', 'install', '7.1.99'])
        from /home/morozov/Projects/phpbrew/bin/phpbrew:23
```

Fixes #108.