### PR TITLE
Improved PHP 7.4 compatibility

### DIFF
--- a/src/Completion/ZshGenerator.php
+++ b/src/Completion/ZshGenerator.php
@@ -187,7 +187,13 @@ class ZshGenerator
         // output description
         $str .= "[" . addcslashes($opt->desc,'[]:') . "]";
 
-        $placeholder = ($opt->valueName) ? $opt->valueName : $opt->isa ? $opt->isa : null;
+        if ($opt->valueName) {
+            $placeholder = $opt->valueName;
+        } elseif ($opt->isa) {
+            $placeholder = $opt->isa;
+        } else {
+            $placeholder = null;
+        }
 
         // has anything to complete
         if ($opt->validValues || $opt->suggestions || $opt->isa) {


### PR DESCRIPTION
On PHP 7.4, the following error is triggered when generating shell completions:

```
$ phpbrew zsh

Deprecated: Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` in vendor/corneltek/cliframework/src/Completion/ZshGenerator.php on line 190
```

See [PHP RFC: Change the precedence of the concatenation operator](https://wiki.php.net/rfc/concatenation_precedence).