### PR TITLE
Upgrade Symfony/Finder to 5.x.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "universal/universal": "2.0.x-dev",
         "corneltek/codegen": "4.0.x-dev",
         "pimple/pimple": "*",
-        "symfony/finder": "~2.8|~3.0|~3.2",
+        "symfony/finder": "~2.8|~3.0|^5.3.4",
         "symfony/class-loader": "~2.8|~3.0|~3.2"
     },
     "require-dev": {


### PR DESCRIPTION
According to composer version [syntax](https://getcomposer.org/doc/articles/versions.md) the tilde (~) allows the last number to increase, which makes ~3.0 and ~3.2 the same thing and that's why I removed the latter.
`^5.3.4` uses the latest version on packagist as base and indicates `>=5.3.4 <6.0.0`.

In theory it works, but didn't have the chance to run composer install and check for bugs.