### PR TITLE
The "::class" constant was not added until php 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "getopt"
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.5.0",
         "corneltek/getoptionkit": "~2.5.4",
         "universal/universal": "2.0.x-dev",
         "corneltek/codegen": "4.0.x-dev",


### PR DESCRIPTION
Changed the composer php requirement bumping it from 5.3 to 5.5 due to the use of the ::class constant in code