### PR TITLE
Fix PHP 8.1 deprecations

### DIFF
--- a/src/CommandBase.php
+++ b/src/CommandBase.php
@@ -913,26 +913,31 @@ abstract class CommandBase implements ArrayAccess, IteratorAggregate, CommandInt
         return $chooser->choose($prompt, $choices);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return isset($this->commands[$key]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->commands[$key] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->commands[$key];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         unset($this->commands[$key]);
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->commands);


### PR DESCRIPTION
Add attribute to non-typehinted interface functions

This could have been fixed by typehinting the functions however to
preserve backwards compatibility to PHP 5.4 this attribute is used
(which is interpreted as a comment in <8.1).