### PR TITLE
return default value

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -192,6 +192,7 @@ class Application extends CommandBase implements CommandInterface
 
     public function usage()
     {
+        return 'application usage';
     }
 
     /**


### PR DESCRIPTION
Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated

If the application does not set the usage, null is passed to the trim() method, and occur deprecated notice.