### PR TITLE
Drop < PHP7.2 versions support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  run:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, zip, xml
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install -n
+
+      - name: Run test suite
+        run: vendor/bin/phpunit
+
+      - name: Run demo script
+        run: example/demo meta --zsh commit arg 0 suggestions && example/demo meta --zsh commit arg 1 valid-values && example/demo zsh --bind demo > zsh

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "getopt"
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.2.0",
         "corneltek/getoptionkit": "~2.6.1",
         "universal/universal": "2.0.x-dev",
         "corneltek/codegen": "4.0.x-dev",
@@ -20,8 +20,9 @@
         "symfony/class-loader": "~2.8|~3.0|~3.2"
     },
     "require-dev": {
-        "corneltek/phpunit-testmore": "dev-master",
-        "satooshi/php-coveralls": "^1"
+        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+        "satooshi/php-coveralls": "^1",
+        "ext-intl": "*"
     },
     "license": "MIT",
     "authors": [

--- a/src/Completion/ZshGenerator.php
+++ b/src/Completion/ZshGenerator.php
@@ -203,7 +203,7 @@ class ZshGenerator
         // output description
         $str .= "[" . addcslashes($opt->desc, '[]:') . "]";
 
-        $placeholder = ($opt->valueName) ? $opt->valueName : $opt->isa ? $opt->isa : null;
+        $placeholder = (($opt->valueName) ? $opt->valueName : $opt->isa) ? $opt->isa : null;
 
         // has anything to complete
         if ($opt->validValues || $opt->suggestions || $opt->isa) {

--- a/src/Component/Table/Table.php
+++ b/src/Component/Table/Table.php
@@ -137,6 +137,9 @@ class Table
 
         $columns = array(count($this->headers));
         foreach ($this->rows as $row) {
+            if (!is_array($row)) {
+                $row = [$row];
+            }
             $columns[] = count($row);
         }
         return $this->numberOfColumns = max($columns);

--- a/src/Testing/CommandTestCase.php
+++ b/src/Testing/CommandTestCase.php
@@ -16,7 +16,7 @@ abstract class CommandTestCase extends TestCase
         return $this->app;
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         if ($this->outputBufferingActive) {
             ob_start();
@@ -24,7 +24,7 @@ abstract class CommandTestCase extends TestCase
         $this->app = static::setupApplication();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         $this->app = null;
         if ($this->outputBufferingActive) {

--- a/tests/CLIFramework/CommandTest.php
+++ b/tests/CLIFramework/CommandTest.php
@@ -9,7 +9,7 @@ class CommandTest extends TestCase
 {
     private $command;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->command = new CommandTestCommand();
     }

--- a/tests/CLIFramework/Component/Table/TableTest.php
+++ b/tests/CLIFramework/Component/Table/TableTest.php
@@ -183,7 +183,7 @@ class TableTest extends TestCase
         $this->assertStringEqualsFile('tests/data/markdown-table.txt', $out);
     }
 
-    static public function assertStringEqualsFile($file, $str, $message = NULL, $canonicalize = false, $ignoreCase = false) {
+    public static function assertStringEqualsFile($file, $str, $message = NULL, $canonicalize = false, $ignoreCase = false): void {
         if ($str instanceof Table) {
             $str = $str->render();
         }
@@ -192,7 +192,7 @@ class TableTest extends TestCase
             echo "Actual:\n";
             echo $str , "\n";
         }
-        parent::assertStringEqualsFile($file, $str, $message, $canonicalize, $ignoreCase);
+        parent::assertStringEqualsFile($file, $str, (string) $message, $canonicalize, $ignoreCase);
     }
 
 }

--- a/tests/CLIFramework/Extension/DaemonExtensionTest.php
+++ b/tests/CLIFramework/Extension/DaemonExtensionTest.php
@@ -21,7 +21,7 @@ class DaemonExtensionTest extends TestCase
 
     private $command;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $extension = new DaemonExtensionForTest;
         if (!$extension->isAvailable()) {
@@ -40,7 +40,7 @@ class DaemonExtensionTest extends TestCase
         $this->command->executeWrapper(array());
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
     }
 }

--- a/tests/CLIFramework/IO/EchoWriterTest.php
+++ b/tests/CLIFramework/IO/EchoWriterTest.php
@@ -16,7 +16,7 @@ class EchoWriterTest extends \PHPUnit\Framework\TestCase
 {
     private $writer;
 
-    function setUp()
+    protected function setUp(): void
     {
         $this->writer = new EchoWriter();
     }

--- a/tests/CLIFramework/IO/NullSttyTest.php
+++ b/tests/CLIFramework/IO/NullSttyTest.php
@@ -16,7 +16,7 @@ class NullSttyTest extends \PHPUnit\Framework\TestCase
 {
     private $stty;
 
-    function setUp()
+    protected function setUp(): void
     {
         $this->stty = new NullStty();
     }

--- a/tests/CLIFramework/IO/StreamWriterTest.php
+++ b/tests/CLIFramework/IO/StreamWriterTest.php
@@ -17,13 +17,13 @@ class StreamWriterTest extends \PHPUnit\Framework\TestCase
     private $writer;
     private $stream;
 
-    function setUp()
+    protected function setUp(): void
     {
         $this->stream = fopen('php://memory', 'rw');
         $this->writer = new StreamWriter($this->stream);
     }
 
-    function tearDown()
+    protected function tearDown(): void
     {
         fclose($this->stream);
     }

--- a/tests/CLIFramework/LoggerTest.php
+++ b/tests/CLIFramework/LoggerTest.php
@@ -16,7 +16,7 @@ class LoggerTest extends TestCase
 {
     private $logger;
 
-    function setUp()
+    protected function setUp(): void
     {
         $this->logger = new \CLIFramework\Logger;
     }

--- a/tests/DemoApp/MetaCommandTest.php
+++ b/tests/DemoApp/MetaCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 namespace DemoApp;
+use CLIFramework\Exception\CommandArgumentNotEnoughException;
+use CLIFramework\Exception\CommandNotFoundException;
 use CLIFramework\Testing\CommandTestCase;
 use CLIFramework\ServiceContainer;
 
@@ -51,20 +53,16 @@ ActionKit
         $this->assertTrue( $this->runCommand('example/demo zsh --program demo --bind demo') );
     }
 
-    /**
-     * @expectedException CLIFramework\Exception\CommandNotFoundException
-     */
     public function testCommandNotFound()
     {
-        $this->assertTrue( $this->runCommand('example/demo --no-interact zzz') );
+        $this->expectException(CommandNotFoundException::class);
+        $this->runCommand('example/demo --no-interact zzz');
     }
 
-    /**
-     * @expectedException CLIFramework\Exception\CommandArgumentNotEnoughException
-     */
     public function testArgument()
     {
-        $this->assertTrue( $this->runCommand('example/demo commit') );
+        $this->expectException(CommandArgumentNotEnoughException::class);
+        $this->runCommand('example/demo commit');
     }
 
 }


### PR DESCRIPTION
# Changed log

- It's related to the `PHPBrew 2.x` updating.
- Drop these PHP versions that are lower than `7.2`.
- Preparing for releasing `4.2.0`.
- Drop Travis CI build. Using the GitHub workflows instead.
- The successful CI build is available [here](https://github.com/peter279k/CLIFramework/actions/runs/3683990172) in my forked repository :).