### PR TITLE
Apply some diff rules via the rector

### DIFF
--- a/src/Ansi/Colors.php
+++ b/src/Ansi/Colors.php
@@ -11,7 +11,7 @@ use InvalidArgumentException;
  */
 class Colors
 {
-    const CODE_PATTERN = '#\033\[\d{0,1}[,;]?\d*(?:;\d2)?m#x';
+    public const CODE_PATTERN = '#\033\[\d{0,1}[,;]?\d*(?:;\d2)?m#x';
 
     protected static $foregroundColors = array(
         'black' => '0;30',

--- a/src/Ansi/CursorControl.php
+++ b/src/Ansi/CursorControl.php
@@ -21,6 +21,7 @@ class CursorControl
      */
     public function home($row, $col)
     {
+        $column = null;
         fwrite($this->fd, "\e[{$row};{$column}H");
     }
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -37,9 +37,9 @@ use BadMethodCallException;
 class Application extends CommandBase
     implements CommandInterface
 {
-    const CORE_VERSION = '2.5.4';
-    const VERSION = "2.8.1";
-    const NAME = 'CLIFramework';
+    public const CORE_VERSION = '2.5.4';
+    public const VERSION = "2.8.1";
+    public const NAME = 'CLIFramework';
 
 
     /**
@@ -123,7 +123,7 @@ class Application extends CommandBase
         $appRefClass = new ReflectionClass($this);
         $appNs = $appRefClass->getNamespaceName();
         $this->loader->addNamespace( '\\' . $appNs . '\\Command' );
-        $this->loader->addNamespace( array('\\CLIFramework\\Command' ));
+        $this->loader->addNamespace( array('\\' . \CLIFramework\Command::class ));
 
         $this->supportReadline = extension_loaded('readline');
     }
@@ -257,14 +257,14 @@ class Application extends CommandBase
     {
         // $this->addCommand('list','CLIFramework\\Command\\ListCommand');
         parent::init();
-        $this->command('help','CLIFramework\\Command\\HelpCommand');
+        $this->command('help',\CLIFramework\Command\HelpCommand::class);
         $this->commandGroup("Development Commands", array(
-            'zsh'                 => 'CLIFramework\\Command\\ZshCompletionCommand',
-            'bash'                => 'CLIFramework\\Command\\BashCompletionCommand',
-            'meta'                => 'CLIFramework\\Command\\MetaCommand',
-            'compile'             => 'CLIFramework\\Command\\CompileCommand',
-            'archive'             => 'CLIFramework\\Command\\ArchiveCommand',
-            'github:build-topics' => 'CLIFramework\\Command\\BuildGitHubWikiTopicsCommand',
+            'zsh'                 => \CLIFramework\Command\ZshCompletionCommand::class,
+            'bash'                => \CLIFramework\Command\BashCompletionCommand::class,
+            'meta'                => \CLIFramework\Command\MetaCommand::class,
+            'compile'             => \CLIFramework\Command\CompileCommand::class,
+            'archive'             => \CLIFramework\Command\ArchiveCommand::class,
+            'github:build-topics' => \CLIFramework\Command\BuildGitHubWikiTopicsCommand::class,
         ))->setId('dev');
     }
 

--- a/src/Autoload/ComposerAutoloadGenerator.php
+++ b/src/Autoload/ComposerAutoloadGenerator.php
@@ -227,9 +227,9 @@ class ComposerAutoloadGenerator
 
         // Generate classloader initialization code
         $block = new Block();
-        $block[] = new UseStatement('Universal\\ClassLoader\\Psr0ClassLoader');
-        $block[] = new UseStatement('Universal\\ClassLoader\\Psr4ClassLoader');
-        $block[] = new UseStatement('Universal\\ClassLoader\\MapClassLoader');
+        $block[] = new UseStatement(\Universal\ClassLoader\Psr0ClassLoader::class);
+        $block[] = new UseStatement(\Universal\ClassLoader\Psr4ClassLoader::class);
+        $block[] = new UseStatement(\Universal\ClassLoader\MapClassLoader::class);
 
         if (!empty($files)) {
             foreach ($files as $file) {

--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -14,8 +14,8 @@ class Buffer {
 
     public $format;
 
-    const FORMAT_UNIX = 0;
-    const FORMAT_DOS = 1;
+    public const FORMAT_UNIX = 0;
+    public const FORMAT_DOS = 1;
 
     public $newline = "\n";
 

--- a/src/Chooser.php
+++ b/src/Chooser.php
@@ -33,6 +33,7 @@ class Chooser
      */
     public function choose($prompt, $choices )
     {
+        $i = null;
         echo $prompt . ": \n";
 
         $choicesMap = array();

--- a/src/Command/ArchiveCommand.php
+++ b/src/Command/ArchiveCommand.php
@@ -144,10 +144,10 @@ class ArchiveCommand extends Command
         // However the class path might be in another directory because the
         // classes are loaded from vendor/autoload.php
         $classPaths = array(
-            Utils::getClassPath('Universal\\ClassLoader\\ClassLoader'),
-            Utils::getClassPath('Universal\\ClassLoader\\Psr0ClassLoader'),
-            Utils::getClassPath('Universal\\ClassLoader\\Psr4ClassLoader'),
-            Utils::getClassPath('Universal\\ClassLoader\\MapClassLoader'),
+            Utils::getClassPath(\Universal\ClassLoader\ClassLoader::class),
+            Utils::getClassPath(\Universal\ClassLoader\Psr0ClassLoader::class),
+            Utils::getClassPath(\Universal\ClassLoader\Psr4ClassLoader::class),
+            Utils::getClassPath(\Universal\ClassLoader\MapClassLoader::class),
         );
 
         // Generate class loader stub

--- a/src/Command/BuildGitHubWikiTopicsCommand.php
+++ b/src/Command/BuildGitHubWikiTopicsCommand.php
@@ -109,7 +109,7 @@ class BuildGitHubWikiTopicsCommand extends Command
                 $cTemplate->addProperty('url', $topicRemoteUrl);
                 $cTemplate->addProperty('title', $topicTitle);
 
-                $cTemplate->extendClass('\\CLIFramework\\Topic\\GitHubTopic');
+                $cTemplate->extendClass('\\' . \CLIFramework\Topic\GitHubTopic::class);
 
                 $cTemplate->addMethod('public', 'getRemoteUrl', array(), 'return $this->remoteUrl;');
                 $cTemplate->addMethod('public', 'getId', array(), 'return $this->id;');

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -185,11 +185,11 @@ class HelpCommand extends Command implements CommandInterface
             $command_classes = array();
             foreach ($classes as $class) {
                 if (version_compare(phpversion(), '5.3.9') >= 0) {
-                    if (is_subclass_of($class, 'CLIFramework\\Command', true)) {
+                    if (is_subclass_of($class, \CLIFramework\Command::class, true)) {
                         $command_classes[] = $class;
                     }
                 } else {
-                    if (is_subclass_of($class, 'CLIFramework\\Command')) {
+                    if (is_subclass_of($class, \CLIFramework\Command::class)) {
                         $command_classes[] = $class;
                     }
                 }

--- a/src/Command/MetaCommand.php
+++ b/src/Command/MetaCommand.php
@@ -288,7 +288,7 @@ class MetaCommand extends Command
             if ($opts->zsh) {
                 // for zsh, we output the first line as the label
                 foreach ($values as $value) {
-                    list($key, $val) = $value;
+                    [$key, $val] = $value;
                     $this->logger->writeln("$key:".addcslashes($val, ':'));
                 }
             } else {

--- a/src/CommandAutoloader.php
+++ b/src/CommandAutoloader.php
@@ -77,6 +77,7 @@ class CommandAutoloader
 
     private function translateFileNameToCommand($fileName)
     {
+        $matches = [];
         $extensions = explode(',', spl_autoload_extensions());
         $isCommandClassFile = ($fileName[0] !== '.'
             and preg_match('/(^.*Command)(\..*)$/', $fileName, $matches) === 1

--- a/src/Completion/ZshGenerator.php
+++ b/src/Completion/ZshGenerator.php
@@ -168,7 +168,7 @@ class ZshGenerator
         $str = "";
 
         $optspec = $opt->flag || $opt->optional ? '' : '=';
-        $optName = $opt->long ? $opt->long : $opt->short;
+        $optName = $opt->long ?: $opt->short;
 
         if ($opt->short && $opt->long) {
             if (!$opt->multiple) {
@@ -187,7 +187,7 @@ class ZshGenerator
         // output description
         $str .= "[" . addcslashes($opt->desc,'[]:') . "]";
 
-        $placeholder = (($opt->valueName) ? $opt->valueName : $opt->isa) ? $opt->isa : null;
+        $placeholder = ($opt->valueName ?: $opt->isa) ? $opt->isa : null;
 
         // has anything to complete
         if ($opt->validValues || $opt->suggestions || $opt->isa) {

--- a/src/Component/Table/CellAttribute.php
+++ b/src/Component/Table/CellAttribute.php
@@ -4,17 +4,17 @@ use CLIFramework\Ansi\Colors;
 
 class CellAttribute { 
 
-    const ALIGN_RIGHT = 1;
+    public const ALIGN_RIGHT = 1;
 
-    const ALIGN_LEFT = 2;
+    public const ALIGN_LEFT = 2;
 
-    const ALIGN_CENTER = 3;
+    public const ALIGN_CENTER = 3;
 
-    const WRAP = 1;
+    public const WRAP = 1;
 
-    const CLIP = 2;
+    public const CLIP = 2;
 
-    const ELLIPSIS = 3;
+    public const ELLIPSIS = 3;
 
     protected $alignment = 2;
 

--- a/src/LevenshteinCorrector.php
+++ b/src/LevenshteinCorrector.php
@@ -4,6 +4,7 @@ namespace CLIFramework;
 class LevenshteinCorrector extends Corrector
 {
     public function match($input) {
+        $closet = null;
         // no shortest distance found, yet
         $shortest = -1;
 

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -168,7 +168,7 @@ class Logger
     public function __call($method, $args)
     {
         $msg = $args[0];
-        $indent = isset($args[1]) ? $args[1] : 0;
+        $indent = $args[1] ?? 0;
         $level = $this->getLevelByName($method);
         $style = $this->getStyleByName($method);
         if ($level > $this->level) {
@@ -263,6 +263,6 @@ class Logger
     public static function getInstance()
     {
         static $instance;
-        return $instance ? $instance : $instance = new static;
+        return $instance ?: ($instance = new static);
     }
 }


### PR DESCRIPTION
Using the `rector` to apply the following rules:

```diff
 15/15 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
15 files with changes
=====================

1) src/Logger.php:167

    ---------- begin diff ----------
@@ @@
     public function __call($method, $args)
     {
         $msg = $args[0];
-        $indent = isset($args[1]) ? $args[1] : 0;
+        $indent = $args[1] ?? 0;
         $level = $this->getLevelByName($method);
         $style = $this->getStyleByName($method);
         if ($level > $this->level) {
@@ @@
     public static function getInstance()
     {
         static $instance;
-        return $instance ? $instance : $instance = new static;
+        return $instance ?: ($instance = new static);
     }
 }
    ----------- end diff -----------

Applied rules:
 * TernaryToElvisRector (http://php.net/manual/en/language.operators.comparison.php#language.operators.comparison.ternary https://stackoverflow.com/a/1993455/1348344)
 * TernaryToNullCoalescingRector


2) src/LevenshteinCorrector.php:3

    ---------- begin diff ----------
@@ @@
 class LevenshteinCorrector extends Corrector
 {
     public function match($input) {
+        $closet = null;
         // no shortest distance found, yet
         $shortest = -1;
    ----------- end diff -----------

Applied rules:
 * AddDefaultValueForUndefinedVariableRector (https://github.com/vimeo/psalm/blob/29b70442b11e3e66113935a2ee22e165a70c74a4/docs/fixing_code.md#possiblyundefinedvariable)


3) src/Component/Table/CellAttribute.php:3

    ---------- begin diff ----------
@@ @@

 class CellAttribute {

-    const ALIGN_RIGHT = 1;
+    public const ALIGN_RIGHT = 1;

-    const ALIGN_LEFT = 2;
+    public const ALIGN_LEFT = 2;

-    const ALIGN_CENTER = 3;
+    public const ALIGN_CENTER = 3;

-    const WRAP = 1;
+    public const WRAP = 1;

-    const CLIP = 2;
+    public const CLIP = 2;

-    const ELLIPSIS = 3;
+    public const ELLIPSIS = 3;

     protected $alignment = 2;
    ----------- end diff -----------

Applied rules:
 * PublicConstantVisibilityRector (https://wiki.php.net/rfc/class_const_visibility)


4) src/Completion/ZshGenerator.php:167

    ---------- begin diff ----------
@@ @@
         $str = "";

         $optspec = $opt->flag || $opt->optional ? '' : '=';
-        $optName = $opt->long ? $opt->long : $opt->short;
+        $optName = $opt->long ?: $opt->short;

         if ($opt->short && $opt->long) {
             if (!$opt->multiple) {
@@ @@
         // output description
         $str .= "[" . addcslashes($opt->desc,'[]:') . "]";

-        $placeholder = (($opt->valueName) ? $opt->valueName : $opt->isa) ? $opt->isa : null;
+        $placeholder = ($opt->valueName ?: $opt->isa) ? $opt->isa : null;

         // has anything to complete
         if ($opt->validValues || $opt->suggestions || $opt->isa) {
    ----------- end diff -----------

Applied rules:
 * TernaryToElvisRector (http://php.net/manual/en/language.operators.comparison.php#language.operators.comparison.ternary https://stackoverflow.com/a/1993455/1348344)


5) src/CommandAutoloader.php:76

    ---------- begin diff ----------
@@ @@

     private function translateFileNameToCommand($fileName)
     {
+        $matches = [];
         $extensions = explode(',', spl_autoload_extensions());
         $isCommandClassFile = ($fileName[0] !== '.'
             and preg_match('/(^.*Command)(\..*)$/', $fileName, $matches) === 1
    ----------- end diff -----------

Applied rules:
 * AddDefaultValueForUndefinedVariableRector (https://github.com/vimeo/psalm/blob/29b70442b11e3e66113935a2ee22e165a70c74a4/docs/fixing_code.md#possiblyundefinedvariable)


6) src/Command/MetaCommand.php:287

    ---------- begin diff ----------
@@ @@
             if ($opts->zsh) {
                 // for zsh, we output the first line as the label
                 foreach ($values as $value) {
-                    list($key, $val) = $value;
+                    [$key, $val] = $value;
                     $this->logger->writeln("$key:".addcslashes($val, ':'));
                 }
             } else {
    ----------- end diff -----------

Applied rules:
 * ListToArrayDestructRector (https://wiki.php.net/rfc/short_list_syntax https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.symmetric-array-destructuring)


7) src/Command/HelpCommand.php:184

    ---------- begin diff ----------
@@ @@
             $command_classes = array();
             foreach ($classes as $class) {
                 if (version_compare(phpversion(), '5.3.9') >= 0) {
-                    if (is_subclass_of($class, 'CLIFramework\\Command', true)) {
+                    if (is_subclass_of($class, \CLIFramework\Command::class, true)) {
                         $command_classes[] = $class;
                     }
                 } else {
-                    if (is_subclass_of($class, 'CLIFramework\\Command')) {
+                    if (is_subclass_of($class, \CLIFramework\Command::class)) {
                         $command_classes[] = $class;
                     }
                 }
    ----------- end diff -----------

Applied rules:
 * StringClassNameToClassConstantRector (https://wiki.php.net/rfc/class_name_scalars https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#form)


8) src/Command/BuildGitHubWikiTopicsCommand.php:108

    ---------- begin diff ----------
@@ @@
                 $cTemplate->addProperty('url', $topicRemoteUrl);
                 $cTemplate->addProperty('title', $topicTitle);

-                $cTemplate->extendClass('\\CLIFramework\\Topic\\GitHubTopic');
+                $cTemplate->extendClass('\\' . \CLIFramework\Topic\GitHubTopic::class);

                 $cTemplate->addMethod('public', 'getRemoteUrl', array(), 'return $this->remoteUrl;');
                 $cTemplate->addMethod('public', 'getId', array(), 'return $this->id;');
    ----------- end diff -----------

Applied rules:
 * StringClassNameToClassConstantRector (https://wiki.php.net/rfc/class_name_scalars https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#form)


9) src/Command/ArchiveCommand.php:143

    ---------- begin diff ----------
@@ @@
         // However the class path might be in another directory because the
         // classes are loaded from vendor/autoload.php
         $classPaths = array(
-            Utils::getClassPath('Universal\\ClassLoader\\ClassLoader'),
-            Utils::getClassPath('Universal\\ClassLoader\\Psr0ClassLoader'),
-            Utils::getClassPath('Universal\\ClassLoader\\Psr4ClassLoader'),
-            Utils::getClassPath('Universal\\ClassLoader\\MapClassLoader'),
+            Utils::getClassPath(\Universal\ClassLoader\ClassLoader::class),
+            Utils::getClassPath(\Universal\ClassLoader\Psr0ClassLoader::class),
+            Utils::getClassPath(\Universal\ClassLoader\Psr4ClassLoader::class),
+            Utils::getClassPath(\Universal\ClassLoader\MapClassLoader::class),
         );

         // Generate class loader stub
    ----------- end diff -----------

Applied rules:
 * StringClassNameToClassConstantRector (https://wiki.php.net/rfc/class_name_scalars https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#form)


10) src/Chooser.php:32

    ---------- begin diff ----------
@@ @@
      */
     public function choose($prompt, $choices )
     {
+        $i = null;
         echo $prompt . ": \n";

         $choicesMap = array();
    ----------- end diff -----------

Applied rules:
 * AddDefaultValueForUndefinedVariableRector (https://github.com/vimeo/psalm/blob/29b70442b11e3e66113935a2ee22e165a70c74a4/docs/fixing_code.md#possiblyundefinedvariable)


11) src/Buffer.php:13

    ---------- begin diff ----------
@@ @@

     public $format;

-    const FORMAT_UNIX = 0;
-    const FORMAT_DOS = 1;
+    public const FORMAT_UNIX = 0;
+    public const FORMAT_DOS = 1;

     public $newline = "\n";
    ----------- end diff -----------

Applied rules:
 * PublicConstantVisibilityRector (https://wiki.php.net/rfc/class_const_visibility)


12) src/Autoload/ComposerAutoloadGenerator.php:226

    ---------- begin diff ----------
@@ @@

         // Generate classloader initialization code
         $block = new Block();
-        $block[] = new UseStatement('Universal\\ClassLoader\\Psr0ClassLoader');
-        $block[] = new UseStatement('Universal\\ClassLoader\\Psr4ClassLoader');
-        $block[] = new UseStatement('Universal\\ClassLoader\\MapClassLoader');
+        $block[] = new UseStatement(\Universal\ClassLoader\Psr0ClassLoader::class);
+        $block[] = new UseStatement(\Universal\ClassLoader\Psr4ClassLoader::class);
+        $block[] = new UseStatement(\Universal\ClassLoader\MapClassLoader::class);

         if (!empty($files)) {
             foreach ($files as $file) {
    ----------- end diff -----------

Applied rules:
 * StringClassNameToClassConstantRector (https://wiki.php.net/rfc/class_name_scalars https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#form)


13) src/Application.php:36

    ---------- begin diff ----------
@@ @@
 class Application extends CommandBase
     implements CommandInterface
 {
-    const CORE_VERSION = '2.5.4';
-    const VERSION = "2.8.1";
-    const NAME = 'CLIFramework';
+    public const CORE_VERSION = '2.5.4';
+    public const VERSION = "2.8.1";
+    public const NAME = 'CLIFramework';


     /**
@@ @@
         $appRefClass = new ReflectionClass($this);
         $appNs = $appRefClass->getNamespaceName();
         $this->loader->addNamespace( '\\' . $appNs . '\\Command' );
-        $this->loader->addNamespace( array('\\CLIFramework\\Command' ));
+        $this->loader->addNamespace( array('\\' . \CLIFramework\Command::class ));

         $this->supportReadline = extension_loaded('readline');
     }
@@ @@
     {
         // $this->addCommand('list','CLIFramework\\Command\\ListCommand');
         parent::init();
-        $this->command('help','CLIFramework\\Command\\HelpCommand');
+        $this->command('help',\CLIFramework\Command\HelpCommand::class);
         $this->commandGroup("Development Commands", array(
-            'zsh'                 => 'CLIFramework\\Command\\ZshCompletionCommand',
-            'bash'                => 'CLIFramework\\Command\\BashCompletionCommand',
-            'meta'                => 'CLIFramework\\Command\\MetaCommand',
-            'compile'             => 'CLIFramework\\Command\\CompileCommand',
-            'archive'             => 'CLIFramework\\Command\\ArchiveCommand',
-            'github:build-topics' => 'CLIFramework\\Command\\BuildGitHubWikiTopicsCommand',
+            'zsh'                 => \CLIFramework\Command\ZshCompletionCommand::class,
+            'bash'                => \CLIFramework\Command\BashCompletionCommand::class,
+            'meta'                => \CLIFramework\Command\MetaCommand::class,
+            'compile'             => \CLIFramework\Command\CompileCommand::class,
+            'archive'             => \CLIFramework\Command\ArchiveCommand::class,
+            'github:build-topics' => \CLIFramework\Command\BuildGitHubWikiTopicsCommand::class,
         ))->setId('dev');
     }
    ----------- end diff -----------

Applied rules:
 * StringClassNameToClassConstantRector (https://wiki.php.net/rfc/class_name_scalars https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#form)
 * PublicConstantVisibilityRector (https://wiki.php.net/rfc/class_const_visibility)


14) src/Ansi/CursorControl.php:20

    ---------- begin diff ----------
@@ @@
      */
     public function home($row, $col)
     {
+        $column = null;
         fwrite($this->fd, "\e[{$row};{$column}H");
     }
    ----------- end diff -----------

Applied rules:
 * AddDefaultValueForUndefinedVariableRector (https://github.com/vimeo/psalm/blob/29b70442b11e3e66113935a2ee22e165a70c74a4/docs/fixing_code.md#possiblyundefinedvariable)


15) src/Ansi/Colors.php:10

    ---------- begin diff ----------
@@ @@
  */
 class Colors
 {
-    const CODE_PATTERN = '#\033\[\d{0,1}[,;]?\d*(?:;\d2)?m#x';
+    public const CODE_PATTERN = '#\033\[\d{0,1}[,;]?\d*(?:;\d2)?m#x';

     protected static $foregroundColors = array(
         'black' => '0;30',
    ----------- end diff -----------

Applied rules:
 * PublicConstantVisibilityRector (https://wiki.php.net/rfc/class_const_visibility)



 [OK] 15 files have been changed by Rector
```